### PR TITLE
[RFR] Be a little less agressive with vendor prefixes

### DIFF
--- a/css/zoom.css
+++ b/css/zoom.css
@@ -8,8 +8,6 @@ img[data-action="zoom"] {
   position: relative;
   z-index: 666;
   -webkit-transition: all 300ms;
-     -moz-transition: all 300ms;
-      -ms-transition: all 300ms;
        -o-transition: all 300ms;
           transition: all 300ms;
 }
@@ -28,18 +26,12 @@ img.zoom-img {
   bottom: 0;
   pointer-events: none;
   filter: "alpha(opacity=0)";
-  -khtml-opacity: 0;
-    -moz-opacity: 0;
-         opacity: 0;
+  opacity: 0;
   -webkit-transition:      opacity 300ms;
-     -moz-transition: -moz-opacity 300ms;
-      -ms-transition:      opacity 300ms;
        -o-transition:      opacity 300ms;
           transition:      opacity 300ms;
 }
 .zoom-overlay-open .zoom-overlay {
   filter: "alpha(opacity=100)";
-  -khtml-opacity: 1;
-    -moz-opacity: 1;
-         opacity: 1;
+  opacity: 1;
 }


### PR DESCRIPTION
I am not quite sure which browsers you intend to support but I believe it's safe to get rid of `-khtml-` prefixes as well as `-ms-` and `-moz-` prefixes for transitions (especially since the `-ms-` one has never been used). We could even ditch `-o-` I believe, but I left it just in case.

Feel free to decline if that does not suit your browser needs.
