### PR TITLE
fix(index.html): the site breaks over https

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,8 +52,8 @@
     </p>
 
   </div>
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
-  <script src="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+  <script src="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js"></script>
   <script src="js/zoom.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Issue:
![a](https://www.dropbox.com/s/03i401vjv31zb3e/Screenshot%202015-05-07%2017.18.23.png?dl=1)

Fix:
https should always be used if the content is available over secure protocol.
