### PR TITLE
Fix to force cursor update after animation completes

### DIFF
--- a/css/zoom.css
+++ b/css/zoom.css
@@ -35,11 +35,7 @@ img.zoom-img {
   filter: "alpha(opacity=100)";
   opacity: 1;
 }
-.zoom-overlay-open {
-  cursor: pointer;
-  cursor: -webkit-zoom-out;
-  cursor: -moz-zoom-out;
-}
+.zoom-overlay-open,
 .zoom-overlay-transitioning {
   cursor: default;
 }

--- a/css/zoom.css
+++ b/css/zoom.css
@@ -35,3 +35,11 @@ img.zoom-img {
   filter: "alpha(opacity=100)";
   opacity: 1;
 }
+.zoom-overlay-open {
+  cursor: pointer;
+  cursor: -webkit-zoom-out;
+  cursor: -moz-zoom-out;
+}
+.zoom-overlay-transitioning {
+  cursor: default;
+}


### PR DESCRIPTION
Hopefully this fixes fat/zoom.js#19

This fix changes the body's cursor style during animation, which
forces the zoomed image's cursor style to apply.

Chromium has issues updating the cursor while the cursor is idle.
See [Chromium Issue 26723: Mouse cursor doesn't change when mouse-idling](https://code.google.com/p/chromium/issues/detail?id=26723).
