### PR TITLE
Open in new tab with control key too

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ https://fat.github.io/zoom.js
 
 It's the best way to zoom an image. It transitions/zooms in really smoothly, and then when you're done, scrolls away, [esc] keys away, clicks away… clean af.
 
-Also, now if you hold your meta key (`⌘`), it will open in a new tab. wow.
+Also, now if you hold your meta key (`⌘`) or control key, it will open in a new tab. wow.
 
 
 ### Where

--- a/js/zoom.js
+++ b/js/zoom.js
@@ -29,6 +29,8 @@
 
     if (e.metaKey) return window.open(e.target.src, '_blank')
 
+    if (e.ctrlKey) return window.open(e.target.src, '_blank')
+
     if (target.width >= (window.innerWidth - Zoom.OFFSET)) return
 
     this._activeZoomClose(true)


### PR DESCRIPTION
I just duplicated the metakey+click and set it to control+click so non-osx users can enjoy. Seemed to work fine in my small amount of testing.
