### PR TITLE
Intialise ZoomService listener after document ready

### DIFF
--- a/js/zoom.js
+++ b/js/zoom.js
@@ -218,6 +218,8 @@
     }
   }
 
-  new ZoomService().listen()
+  $(function () {
+    new ZoomService().listen()
+  })
 
 }(jQuery)


### PR DESCRIPTION
Useful if plugin is included before the `<body>` tag.
