### PR TITLE
fix blurred image in chrome - Round translate parameters

### DIFF
--- a/js/zoom.js
+++ b/js/zoom.js
@@ -183,9 +183,9 @@
 
     var imageCenterY = imageOffset.top + (this._targetImage.height / 2)
     var imageCenterX = imageOffset.left + (this._targetImage.width / 2)
-
-    this._translateY = viewportY - imageCenterY
-    this._translateX = viewportX - imageCenterX
+    
+    this._translateY = Math.round(viewportY - imageCenterY)    
+    this._translateX = Math.round(viewportX - imageCenterX)   
 
     $(this._targetImage).css('transform', 'scale(' + this._imgScaleFactor + ')')
     $(this._targetImageWrap).css('transform', 'translate(' + this._translateX + 'px, ' + this._translateY + 'px) translateZ(0)')


### PR DESCRIPTION
Added Math.round() around parameters for the translate to force them to whole numbers and not a decimal value. Since the unit is pixels, decimal values (for examle 20.5) create slightly blurred images (when in 100% zoomed state) in Chrome.
