### PR TITLE
Save and restore the 'style' attribute of the original image.

### DIFF
--- a/js/zoom.js
+++ b/js/zoom.js
@@ -211,6 +211,8 @@
       imageWrapTransform += ' translateZ(0)'
     }
 
+    $(this._targetImage).attr("data-style-backup", $(this._targetImage).attr("style"));
+
     $(this._targetImage)
       .css({
         '-webkit-transform': targetTransform,
@@ -248,6 +250,8 @@
                 'transform': ''
       })
 
+    $(this._targetImage).attr("style", $(this._targetImage).attr("data-style-backup"));
+
     if (!$.support.transition) {
       return this.dispose()
     }
@@ -262,6 +266,8 @@
       $(this._targetImage)
         .removeClass('zoom-img')
         .attr('data-action', 'zoom')
+
+      $(this._targetImage).attr("data-style-backup", '')
 
       this._targetImageWrap.parentNode.replaceChild(this._targetImage, this._targetImageWrap)
       this._overlay.parentNode.removeChild(this._overlay)


### PR DESCRIPTION
Using zoom.js with an image that has a non-trivial `style` before being zoomed in, zooming in works fine, but zooming out was placing the image somewhere else, because the original value of the `style` attribute was lost (in particular, the `translate` property).

This produces a slight visual glitch when zooming in at the default 300ms, but the glitch is absent when setting the delay to 3000ms, so I'm not sure whether it's a bug in my implementation (probably) or in Chrome (unlikely).